### PR TITLE
Remove now default 'sudo: false'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: rust
-sudo: false
 
 rust:
   - stable


### PR DESCRIPTION
'sudo: false' is now default on Travis CI.