### PR TITLE
force proc-macro to be no_std compatable

### DIFF
--- a/lib/macro/Cargo.toml
+++ b/lib/macro/Cargo.toml
@@ -20,6 +20,6 @@ default = ["stable"]
 stable = ["data-encoding-macro-internal/stable", "proc-macro-hack"]
 
 [dependencies]
-data-encoding = { version = "2.2", path = ".." }
+data-encoding = { version = "2.3", path = "..", default-features = false, features = ["alloc"] }
 data-encoding-macro-internal = { version = "0.1.8", path = "internal" }
 proc-macro-hack = { version = "0.5", optional = true }

--- a/lib/macro/internal/Cargo.toml
+++ b/lib/macro/internal/Cargo.toml
@@ -16,6 +16,6 @@ proc-macro = true
 stable = ["proc-macro-hack"]
 
 [dependencies]
-data-encoding = { version = "2.2", path = "../.." }
+data-encoding = { version = "2.3", path = "../..", default-features = false, features = ["alloc"] }
 proc-macro-hack = { version = "0.5", optional = true }
 syn = "1"

--- a/lib/macro/src/lib.rs
+++ b/lib/macro/src/lib.rs
@@ -74,6 +74,7 @@
 
 #![cfg_attr(not(feature = "stable"), feature(proc_macro_hygiene))]
 #![warn(unused_results)]
+#![no_std]
 
 #[cfg(feature = "stable")]
 extern crate proc_macro_hack;


### PR DESCRIPTION
Setting the `no_std` attribute prevents std from leaking into the proc macro... for reasons I am unaware of, but it works (at least while building with `thumbv6m-none-eabi` as the target).

I was hoping to make an `alloc` feature for macro and macro-internal using the pattern I saw already being used in this library, but I couldn't get it to work.

`no_std` for this macro means multiformats/rust-multibase#25 can move ahead without lazy_static (and spin locks).

As a side note, [proc-macro-hack isn't needed](https://github.com/dtolnay/proc-macro-hack) as a default as the proc-macro crate is stable.

