### PR TITLE
Remove stable feature and make macro no-std

### DIFF
--- a/lib/macro/Cargo.toml
+++ b/lib/macro/Cargo.toml
@@ -4,22 +4,14 @@ version = "0.1.8"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "MIT"
 edition = "2018"
-keywords = ["data-encoding", "macro", "static", "const", "compile-time"]
-categories = ["encoding"]
+keywords = ["no_std", "base64", "base32", "hex", "macro"]
+categories = ["encoding", "no-std"]
 readme = "README.md"
 repository = "https://github.com/ia0/data-encoding"
 documentation = "https://docs.rs/data-encoding-macro"
 description = "Macros for data-encoding"
 include = ["Cargo.toml", "LICENSE", "README.md", "src/lib.rs"]
 
-[package.metadata.docs.rs]
-no-default-features = true
-
-[features]
-default = ["stable"]
-stable = ["data-encoding-macro-internal/stable", "proc-macro-hack"]
-
 [dependencies]
-data-encoding = { version = "2.3", path = "..", default-features = false, features = ["alloc"] }
+data-encoding = { version = "2.3", path = "..", default-features = false }
 data-encoding-macro-internal = { version = "0.1.8", path = "internal" }
-proc-macro-hack = { version = "0.5", optional = true }

--- a/lib/macro/README.md
+++ b/lib/macro/README.md
@@ -6,12 +6,6 @@ encodings to be used with the [data-encoding] crate.
 If you were familiar with the [binary_macros] crate, this library is actually
 [inspired][binary_macros_issue] from it.
 
-If you use a nightly compiler, you may disable the "stable" feature:
-
-```
-data-encoding-macro = { version = "0.1", default-features = false }
-```
-
 ### Examples
 
 You can define a compile-time byte slice or array (using the `hexlower` or
@@ -20,7 +14,7 @@ You can define a compile-time byte slice or array (using the `hexlower` or
 ```rust
 const HELLO: &'static [u8] = &hexlower!("68656c6c6f");
 const FOOBAR: &'static [u8] = &base64!("Zm9vYmFy");
-// In nightly, it is possible to define an array instead of a slice:
+// It is possible to define an array instead of a slice:
 hexlower_array!("const HELLO" = "68656c6c6f");
 base64_array!("const FOOBAR" = "Zm9vYmFy");
 ```

--- a/lib/macro/internal/Cargo.toml
+++ b/lib/macro/internal/Cargo.toml
@@ -12,10 +12,6 @@ include = ["Cargo.toml", "LICENSE", "README.md", "src/lib.rs"]
 [lib]
 proc-macro = true
 
-[features]
-stable = ["proc-macro-hack"]
-
 [dependencies]
-data-encoding = { version = "2.3", path = "../..", default-features = false, features = ["alloc"] }
-proc-macro-hack = { version = "0.5", optional = true }
+data-encoding = { version = "2.3", path = "../.." }
 syn = "1"

--- a/lib/macro/internal/src/lib.rs
+++ b/lib/macro/internal/src/lib.rs
@@ -9,17 +9,8 @@
 
 #![warn(unused_results)]
 
-extern crate proc_macro;
-#[cfg(feature = "stable")]
-extern crate proc_macro_hack;
-extern crate syn;
-
-extern crate data_encoding;
-
 use proc_macro::token_stream::IntoIter;
 use proc_macro::{TokenStream, TokenTree};
-#[cfg(feature = "stable")]
-use proc_macro_hack::proc_macro_hack;
 use std::collections::HashMap;
 
 use data_encoding::{BitOrder, Encoding, Specification, Translate, Wrap};
@@ -150,8 +141,7 @@ fn check_empty<T>(hash_map: HashMap<String, T>) {
     }
 }
 
-#[cfg_attr(feature = "stable", proc_macro_hack)]
-#[cfg_attr(not(feature = "stable"), proc_macro)]
+#[proc_macro]
 #[doc(hidden)]
 pub fn internal_new_encoding(input: TokenStream) -> TokenStream {
     let mut hash_map = parse_map(input.into_iter());
@@ -160,7 +150,6 @@ pub fn internal_new_encoding(input: TokenStream) -> TokenStream {
     format!("{:?}", encoding.internal_implementation()).parse().unwrap()
 }
 
-#[cfg(not(feature = "stable"))]
 #[proc_macro]
 #[doc(hidden)]
 pub fn internal_decode_array(input: TokenStream) -> TokenStream {
@@ -175,8 +164,7 @@ pub fn internal_decode_array(input: TokenStream) -> TokenStream {
     format!("{}: [u8; {}] = {:?};", name, output.len(), output).parse().unwrap()
 }
 
-#[cfg_attr(feature = "stable", proc_macro_hack)]
-#[cfg_attr(not(feature = "stable"), proc_macro)]
+#[proc_macro]
 #[doc(hidden)]
 pub fn internal_decode_slice(input: TokenStream) -> TokenStream {
     let mut hash_map = parse_map(input.into_iter());

--- a/lib/macro/tests/lib.rs
+++ b/lib/macro/tests/lib.rs
@@ -1,18 +1,6 @@
-#![cfg_attr(not(feature = "stable"), feature(proc_macro_hygiene))]
-
-extern crate data_encoding;
-#[macro_use]
-extern crate data_encoding_macro;
-
-use std::ops::Deref;
-
-use data_encoding::{BASE64, HEXLOWER};
-#[cfg(not(feature = "stable"))]
-use data_encoding_macro::{decode_array, decode_slice};
-
 // Test the macro invocation from inside a module.
 mod test {
-    const BASE32_DNSCURVE: ::data_encoding::Encoding = new_encoding! {
+    const BASE32_DNSCURVE: data_encoding::Encoding = data_encoding_macro::new_encoding! {
         symbols: "0123456789bcdfghjklmnpqrstuvwxyz",
         bit_order: LeastSignificantFirst,
         translate_from: "BCDFGHJKLMNPQRSTUVWXYZ",
@@ -21,16 +9,15 @@ mod test {
 
     #[test]
     fn base32_dnscurve() {
-        assert_eq!(BASE32_DNSCURVE, ::data_encoding::BASE32_DNSCURVE);
+        assert_eq!(BASE32_DNSCURVE, data_encoding::BASE32_DNSCURVE);
     }
 }
 
-#[cfg(not(feature = "stable"))]
 #[test]
 fn decode_array() {
     macro_rules! base {
         ($f: ident; $($x: tt)*) => {
-            $f!{
+            data_encoding_macro::$f!{
                 symbols: "0123456789abcdef",
                 bit_order: LeastSignificantFirst,
                 padding: None,
@@ -42,15 +29,15 @@ fn decode_array() {
         name: "const OUTPUT",
         input: "deadbeef",
     }
-    const BASE: ::data_encoding::Encoding = base!(new_encoding;);
-    assert_eq!(&OUTPUT, BASE.decode(b"deadbeef").unwrap().deref());
+    const BASE: data_encoding::Encoding = base!(new_encoding;);
+    assert_eq!(&OUTPUT as &[u8], BASE.decode(b"deadbeef").unwrap());
 }
 
 #[test]
 fn decode_slice() {
     macro_rules! base {
         ($f: ident; $($x: tt)*) => {
-            $f!{
+            data_encoding_macro::$f!{
                 symbols: "0123456789abcdef",
                 bit_order: LeastSignificantFirst,
                 padding: None,
@@ -62,32 +49,30 @@ fn decode_slice() {
         decode_slice;
         input: "deadbeef",
     };
-    const BASE: ::data_encoding::Encoding = base!(new_encoding;);
-    assert_eq!(OUTPUT, BASE.decode(b"deadbeef").unwrap().deref());
+    const BASE: data_encoding::Encoding = base!(new_encoding;);
+    assert_eq!(OUTPUT, BASE.decode(b"deadbeef").unwrap());
 }
 
-#[cfg(not(feature = "stable"))]
 #[test]
 fn hexlower_decode_array() {
-    hexlower_array!("const OUTPUT" = "deadbeef");
-    assert_eq!(&OUTPUT, HEXLOWER.decode(b"deadbeef").unwrap().deref());
+    data_encoding_macro::hexlower_array!("const OUTPUT" = "deadbeef");
+    assert_eq!(&OUTPUT as &[u8], data_encoding::HEXLOWER.decode(b"deadbeef").unwrap());
 }
 
-#[cfg(not(feature = "stable"))]
 #[test]
 fn base64_decode_array() {
-    base64_array!("const OUTPUT" = "deadbeef");
-    assert_eq!(&OUTPUT, BASE64.decode(b"deadbeef").unwrap().deref());
+    data_encoding_macro::base64_array!("const OUTPUT" = "deadbeef");
+    assert_eq!(&OUTPUT as &[u8], data_encoding::BASE64.decode(b"deadbeef").unwrap());
 }
 
 #[test]
 fn hexlower_decode() {
-    const OUTPUT: &'static [u8] = &hexlower!("deadbeef");
-    assert_eq!(OUTPUT, HEXLOWER.decode(b"deadbeef").unwrap().deref());
+    const OUTPUT: &'static [u8] = &data_encoding_macro::hexlower!("deadbeef");
+    assert_eq!(OUTPUT, data_encoding::HEXLOWER.decode(b"deadbeef").unwrap());
 }
 
 #[test]
 fn base64_decode() {
-    const OUTPUT: &'static [u8] = &base64!("deadbeef");
-    assert_eq!(OUTPUT, BASE64.decode(b"deadbeef").unwrap().deref());
+    const OUTPUT: &'static [u8] = &data_encoding_macro::base64!("deadbeef");
+    assert_eq!(OUTPUT, data_encoding::BASE64.decode(b"deadbeef").unwrap());
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -169,29 +169,22 @@
 //! [github]: https://github.com/ia0/data-encoding
 //! [macro]: https://crates.io/crates/data-encoding-macro
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![warn(unused_results, missing_docs)]
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-extern crate alloc;
-
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-mod prelude {
-    pub use alloc::borrow::Cow;
-    pub use alloc::borrow::ToOwned;
-    pub use alloc::string::String;
-    pub use alloc::vec;
-    pub use alloc::vec::Vec;
-}
-#[cfg(feature = "std")]
-mod prelude {
-    pub use std::borrow::Cow;
-}
-
-#[cfg(not(feature = "std"))]
-use core as std;
 #[cfg(feature = "alloc")]
-use self::prelude::*;
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "alloc")]
+use alloc::borrow::{Cow, ToOwned};
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+#[cfg(feature = "alloc")]
+use alloc::vec;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 macro_rules! check {
     ($e: expr, $c: expr) => {
@@ -273,12 +266,12 @@ macro_rules! dispatch {
 unsafe fn chunk_unchecked(x: &[u8], n: usize, i: usize) -> &[u8] {
     debug_assert!((i + 1) * n <= x.len());
     let ptr = x.as_ptr().add(n * i);
-    std::slice::from_raw_parts(ptr, n)
+    core::slice::from_raw_parts(ptr, n)
 }
 unsafe fn chunk_mut_unchecked(x: &mut [u8], n: usize, i: usize) -> &mut [u8] {
     debug_assert!((i + 1) * n <= x.len());
     let ptr = x.as_mut_ptr().add(n * i);
-    std::slice::from_raw_parts_mut(ptr, n)
+    core::slice::from_raw_parts_mut(ptr, n)
 }
 unsafe fn as_array(x: &[u8]) -> &[u8; 256] {
     debug_assert_eq!(x.len(), 256);
@@ -1502,7 +1495,7 @@ impl Encoding {
         let mut specification = Specification::new();
         specification
             .symbols
-            .push_str(std::str::from_utf8(&self.sym()[0 .. 1 << self.bit()]).unwrap());
+            .push_str(core::str::from_utf8(&self.sym()[0 .. 1 << self.bit()]).unwrap());
         specification.bit_order =
             if self.msb() { MostSignificantFirst } else { LeastSignificantFirst };
         specification.check_trailing_bits = self.ctb();
@@ -1517,7 +1510,7 @@ impl Encoding {
         }
         if let Some((col, end)) = self.wrap() {
             specification.wrap.width = col;
-            specification.wrap.separator = std::str::from_utf8(end).unwrap().to_owned();
+            specification.wrap.separator = core::str::from_utf8(end).unwrap().to_owned();
         }
         for i in 0 .. 128u8 {
             let canonical = if self.val()[i as usize] < 1 << self.bit() {
@@ -1572,8 +1565,8 @@ use crate::SpecificationErrorImpl::*;
 pub struct SpecificationError(SpecificationErrorImpl);
 
 #[cfg(feature = "alloc")]
-impl std::fmt::Display for SpecificationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for SpecificationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self.0 {
             BadSize => write!(f, "invalid number of symbols"),
             NotAscii => write!(f, "non-ascii character"),

--- a/nostd/.cargo/config.toml
+++ b/nostd/.cargo/config.toml
@@ -1,0 +1,2 @@
+[unstable]
+features = ["host_dep"]

--- a/nostd/Cargo.toml
+++ b/nostd/Cargo.toml
@@ -7,11 +7,11 @@ license = "MIT"
 publish = false
 
 [features]
-alloc = ["data-encoding/alloc", "data-encoding-macro"]
+alloc = ["data-encoding/alloc"]
 
 [dependencies]
 data-encoding = { path = "../lib", default-features = false }
-data-encoding-macro = { path = "../lib/macro", optional = true }
+data-encoding-macro = { path = "../lib/macro" }
 libc = { version = "0.2", default-features = false }
 
 [profile.release]

--- a/nostd/src/main.rs
+++ b/nostd/src/main.rs
@@ -74,13 +74,8 @@ fn test(encoding: &Encoding, input: &[u8], output: &str, buffer: &mut [u8]) {
 
 #[cfg(feature = "alloc")]
 fn test_macro() {
-    // TODO(ia0): We shouldn't need to import decode_slice. Might be fixed by #36.
-    use data_encoding_macro::{
-        base64, decode_slice, internal_decode_slice, internal_new_encoding, new_encoding,
-    };
-
-    const FOOBAR: &'static [u8] = &base64!("Zm9vYmFy");
-    const LETTER8: Encoding = new_encoding! {
+    const FOOBAR: &'static [u8] = &data_encoding_macro::base64!("Zm9vYmFy");
+    const LETTER8: Encoding = data_encoding_macro::new_encoding! {
         symbols: "ABCDEFGH",
     };
 
@@ -91,12 +86,11 @@ fn test_macro() {
 
 #[no_mangle]
 pub extern "C" fn main(_argc: isize, _argv: *const *const u8) -> isize {
-    use data_encoding::{BASE32, BASE64, BASE64_NOPAD, HEXLOWER_PERMISSIVE};
-    test(&BASE32, b"hello", "NBSWY3DP", &mut [0; 8]);
-    test(&BASE64, b"hello", "aGVsbG8=", &mut [0; 8]);
-    test(&BASE64_NOPAD, b"hello", "aGVsbG8", &mut [0; 8]);
-    test(&HEXLOWER_PERMISSIVE, b"hello", "68656c6c6f", &mut [0; 10]);
-    test_decode(&HEXLOWER_PERMISSIVE, "68656C6C6F", &mut [0; 5], b"hello");
+    test(&data_encoding::BASE32, b"hello", "NBSWY3DP", &mut [0; 8]);
+    test(&data_encoding::BASE64, b"hello", "aGVsbG8=", &mut [0; 8]);
+    test(&data_encoding::BASE64_NOPAD, b"hello", "aGVsbG8", &mut [0; 8]);
+    test(&data_encoding::HEXLOWER_PERMISSIVE, b"hello", "68656c6c6f", &mut [0; 10]);
+    test_decode(&data_encoding::HEXLOWER_PERMISSIVE, "68656C6C6F", &mut [0; 5], b"hello");
     #[cfg(feature = "alloc")]
     test_macro();
     let _ = writeln!(Fd(1), "All tests passed.");

--- a/travis.sh
+++ b/travis.sh
@@ -29,14 +29,6 @@ git clean -fxd
   if [ "$TRAVIS_RUST_VERSION" = nightly ]; then
     info "Benchmark library"
     cargo bench --verbose
-
-    ( cd macro
-      info "Build macro library (no stable feature)"
-      cargo build --verbose --no-default-features
-
-      info "Test macro library (no stable feature)"
-      cargo test --verbose --no-default-features
-    )
   fi
 )
 ( [ "$TRAVIS_RUST_VERSION" = nightly ] || exit 0


### PR DESCRIPTION
This fixes #36 and fixes #37 (when using `host_dep` cargo feature).