### PR TITLE
lib/macro/internal: Only use alloc instead of std

### DIFF
--- a/lib/macro/internal/Cargo.toml
+++ b/lib/macro/internal/Cargo.toml
@@ -13,5 +13,5 @@ include = ["Cargo.toml", "LICENSE", "README.md", "src/lib.rs"]
 proc-macro = true
 
 [dependencies]
-data-encoding = { version = "2.3", path = "../.." }
+data-encoding = { version = "2.3", path = "../..", default-features = false, features = ["alloc"] }
 syn = "1"


### PR DESCRIPTION
Fix #47

The problem was that for stable compilers older than 1.51, we used to support no-std alloc environments, but not no-alloc environments. This was accidentally rolled-back in 76e21dd4134897aff1cabf017844e4e177ef926f. For compilers 1.51 and later, we additionally support no-alloc environments using `resolver = "2"` in `Cargo.toml` of the end binary.