### PR TITLE
Hide the internal implementation of Encoding in the documentation

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-encoding-bin"
-version = "0.3.2"
+version = "0.3.3-git"
 authors = ["Julien Cretin <git@ia0.eu>"]
 license = "MIT"
 edition = "2021"
@@ -16,5 +16,5 @@ name = "data-encoding"
 path = "src/main.rs"
 
 [dependencies]
-data-encoding = { version = "2", path = "../lib" }
+data-encoding = { version = "2.4.1-git", path = "../lib" }
 getopts = "0.2"

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.4.1-git
+
+### Patch
+
+- Hide the documentation of the `Encoding` implementation (fixes #75)
+
 ## 2.4.0
 
 ### Minor

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-encoding"
-version = "2.4.0"
+version = "2.4.1-git"
 authors = ["Julien Cretin <git@ia0.eu>"]
 license = "MIT"
 edition = "2018"

--- a/lib/macro/Cargo.toml
+++ b/lib/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-encoding-macro"
-version = "0.1.13"
+version = "0.1.14-git"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "MIT"
 edition = "2018"
@@ -14,5 +14,5 @@ description = "Macros for data-encoding"
 include = ["Cargo.toml", "LICENSE", "README.md", "src/lib.rs"]
 
 [dependencies]
-data-encoding = { version = "2.4", path = "..", default-features = false }
-data-encoding-macro-internal = { version = "0.1.11", path = "internal" }
+data-encoding = { version = "2.4.1-git", path = "..", default-features = false }
+data-encoding-macro-internal = { version = "0.1.12-git", path = "internal" }

--- a/lib/macro/internal/Cargo.toml
+++ b/lib/macro/internal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-encoding-macro-internal"
-version = "0.1.11"
+version = "0.1.12-git"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "MIT"
 edition = "2018"
@@ -14,5 +14,10 @@ include = ["Cargo.toml", "LICENSE", "README.md", "src/lib.rs"]
 proc-macro = true
 
 [dependencies]
-data-encoding = { version = "2.4", path = "../..", default-features = false, features = ["alloc"] }
-syn = { version = "1", default-features = false, features = ["parsing", "proc-macro"] }
+data-encoding = { version = "2.4.1-git", path = "../..", default-features = false, features = [
+  "alloc",
+] }
+syn = { version = "1", default-features = false, features = [
+  "parsing",
+  "proc-macro",
+] }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -871,7 +871,7 @@ pub type InternalEncoding = &'static [u8];
 // - width % dec(bit) == 0
 // - for all x in separator values[x] is IGNORE
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Encoding(pub InternalEncoding);
+pub struct Encoding(#[doc(hidden)] pub InternalEncoding);
 
 /// How to translate characters when decoding
 ///


### PR DESCRIPTION
The implementation itself (`InternalEncoding`) is already hidden, but the field in the definition of `Encoding` is not.

Fixes #75