### PR TITLE
Bump MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,36 +206,36 @@ jobs:
       - name: cd lib/macro && cargo +stable semver-checks check-release
         run: cargo +stable semver-checks check-release
         working-directory: lib/macro
-      - run: rustup install 1.47
-      - name: cd lib && cargo +1.47 build
-        run: cargo +1.47 build
+      - run: rustup install 1.70
+      - name: cd lib && cargo +1.70 build
+        run: cargo +1.70 build
         working-directory: lib
-      - name: cd lib && cargo +1.47 build --release
-        run: cargo +1.47 build --release
+      - name: cd lib && cargo +1.70 build --release
+        run: cargo +1.70 build --release
         working-directory: lib
-      - name: cd lib && cargo +1.47 build --no-default-features --features=alloc
-        run: cargo +1.47 build --no-default-features --features=alloc
+      - name: cd lib && cargo +1.70 build --no-default-features --features=alloc
+        run: cargo +1.70 build --no-default-features --features=alloc
         working-directory: lib
-      - name: cd lib && cargo +1.47 build --release --no-default-features --features=alloc
-        run: cargo +1.47 build --release --no-default-features --features=alloc
+      - name: cd lib && cargo +1.70 build --release --no-default-features --features=alloc
+        run: cargo +1.70 build --release --no-default-features --features=alloc
         working-directory: lib
-      - name: cd lib && cargo +1.47 build --no-default-features
-        run: cargo +1.47 build --no-default-features
+      - name: cd lib && cargo +1.70 build --no-default-features
+        run: cargo +1.70 build --no-default-features
         working-directory: lib
-      - name: cd lib && cargo +1.47 build --release --no-default-features
-        run: cargo +1.47 build --release --no-default-features
+      - name: cd lib && cargo +1.70 build --release --no-default-features
+        run: cargo +1.70 build --release --no-default-features
         working-directory: lib
-      - name: cd lib/macro/internal && cargo +1.47 build
-        run: cargo +1.47 build
+      - name: cd lib/macro/internal && cargo +1.70 build
+        run: cargo +1.70 build
         working-directory: lib/macro/internal
-      - name: cd lib/macro/internal && cargo +1.47 build --release
-        run: cargo +1.47 build --release
+      - name: cd lib/macro/internal && cargo +1.70 build --release
+        run: cargo +1.70 build --release
         working-directory: lib/macro/internal
-      - name: cd lib/macro && cargo +1.47 build
-        run: cargo +1.47 build
+      - name: cd lib/macro && cargo +1.70 build
+        run: cargo +1.70 build
         working-directory: lib/macro
-      - name: cd lib/macro && cargo +1.47 build --release
-        run: cargo +1.47 build --release
+      - name: cd lib/macro && cargo +1.70 build --release
+        run: cargo +1.70 build --release
         working-directory: lib/macro
   windows:
     runs-on: windows-latest
@@ -315,34 +315,34 @@ jobs:
       - name: cd bin && cargo +stable build --release
         run: cargo +stable build --release
         working-directory: bin
-      - run: rustup install 1.47
-      - name: cd lib && cargo +1.47 build
-        run: cargo +1.47 build
+      - run: rustup install 1.70
+      - name: cd lib && cargo +1.70 build
+        run: cargo +1.70 build
         working-directory: lib
-      - name: cd lib && cargo +1.47 build --release
-        run: cargo +1.47 build --release
+      - name: cd lib && cargo +1.70 build --release
+        run: cargo +1.70 build --release
         working-directory: lib
-      - name: cd lib && cargo +1.47 build --no-default-features --features=alloc
-        run: cargo +1.47 build --no-default-features --features=alloc
+      - name: cd lib && cargo +1.70 build --no-default-features --features=alloc
+        run: cargo +1.70 build --no-default-features --features=alloc
         working-directory: lib
-      - name: cd lib && cargo +1.47 build --release --no-default-features --features=alloc
-        run: cargo +1.47 build --release --no-default-features --features=alloc
+      - name: cd lib && cargo +1.70 build --release --no-default-features --features=alloc
+        run: cargo +1.70 build --release --no-default-features --features=alloc
         working-directory: lib
-      - name: cd lib && cargo +1.47 build --no-default-features
-        run: cargo +1.47 build --no-default-features
+      - name: cd lib && cargo +1.70 build --no-default-features
+        run: cargo +1.70 build --no-default-features
         working-directory: lib
-      - name: cd lib && cargo +1.47 build --release --no-default-features
-        run: cargo +1.47 build --release --no-default-features
+      - name: cd lib && cargo +1.70 build --release --no-default-features
+        run: cargo +1.70 build --release --no-default-features
         working-directory: lib
-      - name: cd lib/macro/internal && cargo +1.47 build
-        run: cargo +1.47 build
+      - name: cd lib/macro/internal && cargo +1.70 build
+        run: cargo +1.70 build
         working-directory: lib/macro/internal
-      - name: cd lib/macro/internal && cargo +1.47 build --release
-        run: cargo +1.47 build --release
+      - name: cd lib/macro/internal && cargo +1.70 build --release
+        run: cargo +1.70 build --release
         working-directory: lib/macro/internal
-      - name: cd lib/macro && cargo +1.47 build
-        run: cargo +1.47 build
+      - name: cd lib/macro && cargo +1.70 build
+        run: cargo +1.70 build
         working-directory: lib/macro
-      - name: cd lib/macro && cargo +1.47 build --release
-        run: cargo +1.47 build --release
+      - name: cd lib/macro && cargo +1.70 build --release
+        run: cargo +1.70 build --release
         working-directory: lib/macro

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -16,5 +16,5 @@ name = "data-encoding"
 path = "src/main.rs"
 
 [dependencies]
-data-encoding = { version = "2.4.1-git", path = "../lib" }
+data-encoding = { version = "2.5.0-git", path = "../lib" }
 getopts = "0.2"

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 2.4.1-git
+## 2.5.0-git
+
+### Minor
+
+- Bump MSRV from 1.47 to 1.70
 
 ### Patch
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "data-encoding"
-version = "2.4.1-git"
+version = "2.5.0-git"
 authors = ["Julien Cretin <git@ia0.eu>"]
 license = "MIT"
 edition = "2018"
-rust-version = "1.47"
+rust-version = "1.70"
 keywords = ["no_std", "base64", "base32", "hex"]
 categories = ["encoding", "no-std"]
 readme = "README.md"

--- a/lib/macro/Cargo.toml
+++ b/lib/macro/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.14-git"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "MIT"
 edition = "2018"
-rust-version = "1.47"
+rust-version = "1.70"
 keywords = ["no_std", "base64", "base32", "hex", "macro"]
 categories = ["encoding", "no-std"]
 readme = "README.md"
@@ -14,5 +14,5 @@ description = "Macros for data-encoding"
 include = ["Cargo.toml", "LICENSE", "README.md", "src/lib.rs"]
 
 [dependencies]
-data-encoding = { version = "2.4.1-git", path = "..", default-features = false }
+data-encoding = { version = "2.5.0-git", path = "..", default-features = false }
 data-encoding-macro-internal = { version = "0.1.12-git", path = "internal" }

--- a/lib/macro/internal/Cargo.toml
+++ b/lib/macro/internal/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.12-git"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "MIT"
 edition = "2018"
-rust-version = "1.47"
+rust-version = "1.70"
 description = "Internal library for data-encoding-macro"
 readme = "README.md"
 repository = "https://github.com/ia0/data-encoding"
@@ -13,11 +13,13 @@ include = ["Cargo.toml", "LICENSE", "README.md", "src/lib.rs"]
 [lib]
 proc-macro = true
 
-[dependencies]
-data-encoding = { version = "2.4.1-git", path = "../..", default-features = false, features = [
-  "alloc",
-] }
-syn = { version = "1", default-features = false, features = [
-  "parsing",
-  "proc-macro",
-] }
+[dependencies.data-encoding]
+version = "2.5.0-git"
+path = "../.."
+default-features = false
+features = ["alloc"]
+
+[dependencies.syn]
+version = "1"
+default-features = false
+features = ["parsing", "proc-macro"]

--- a/nostd/src/main.rs
+++ b/nostd/src/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![allow(internal_features)]
 #![feature(lang_items)]
 
 use core::fmt::Write;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -32,7 +32,7 @@ enum Toolchain {
     #[strum(serialize = "stable")]
     Stable,
 
-    #[strum(serialize = "1.47")]
+    #[strum(serialize = "1.70")]
     Msrv,
 }
 


### PR DESCRIPTION
The bump is needed because of proc-macro2.

Also disable lang_items lint for nostd test.