### PR TITLE
Remove vb64 until build is fixed

### DIFF
--- a/cmp/Cargo.toml
+++ b/cmp/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 base64 = { git = "https://github.com/marshallpierce/rust-base64" }
 data-encoding = { path = "../lib" }
 libc = "0.2"
-vb64 = { git = "https://github.com/mcy/vb64" }
 
 [build-dependencies]
 cc = "1"

--- a/cmp/benches/lib.rs
+++ b/cmp/benches/lib.rs
@@ -69,49 +69,39 @@ fn b06_encode_base64(b: &mut Bencher) {
 }
 
 #[bench]
-fn b07_encode_vb64(b: &mut Bencher) {
-    encode(b, |x| vb64::encode(x));
-}
-
-#[bench]
-fn b08_decode_mut_seq_gcc(b: &mut Bencher) {
+fn b50_decode_mut_seq_gcc(b: &mut Bencher) {
     decode_mut(b, cmp::base64_decode_seq_gcc);
 }
 
 #[bench]
-fn b09_decode_mut_seq_clang(b: &mut Bencher) {
+fn b51_decode_mut_seq_clang(b: &mut Bencher) {
     decode_mut(b, cmp::base64_decode_seq_clang);
 }
 
 #[bench]
-fn b10_decode_mut_par_clang(b: &mut Bencher) {
+fn b52_decode_mut_par_clang(b: &mut Bencher) {
     decode_mut(b, cmp::base64_decode_par_clang);
 }
 
 #[bench]
-fn b11_decode_mut_par_gcc(b: &mut Bencher) {
+fn b53_decode_mut_par_gcc(b: &mut Bencher) {
     decode_mut(b, cmp::base64_decode_par_gcc);
 }
 
 #[bench]
-fn b12_decode_mut_crate(b: &mut Bencher) {
+fn b54_decode_mut_crate(b: &mut Bencher) {
     let base64_decode = |input: &[u8], output: &mut [u8]| BASE64.decode_mut(input, output);
     decode_mut(b, base64_decode);
 }
 
 #[bench]
-fn b13_decode_crate(b: &mut Bencher) {
+fn b55_decode_crate(b: &mut Bencher) {
     let base64_decode = |input: &[u8]| BASE64.decode(input);
     decode(b, base64_decode);
 }
 
 #[bench]
-fn b14_decode_base64(b: &mut Bencher) {
+fn b56_decode_base64(b: &mut Bencher) {
     use base64::Engine;
     decode(b, |x| base64::engine::general_purpose::STANDARD.decode(x));
-}
-
-#[bench]
-fn b15_decode_vb64(b: &mut Bencher) {
-    decode(b, |x| vb64::decode(x));
 }


### PR DESCRIPTION
This essentially reverts #93. This could be reverted back once https://github.com/mcy/vb64/issues/2 is fixed.