### PR TITLE
Add a feature for each bit-width

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.6.0
+
+### Minor
+
+- Add `base2`, `base4`, `base8`, `base16`, `base32`, and `base64` features
+
 ## 2.5.0
 
 ### Minor

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-encoding"
-version = "2.5.0"
+version = "2.6.0"
 authors = ["Julien Cretin <git@ia0.eu>"]
 license = "MIT"
 edition = "2018"
@@ -18,6 +18,17 @@ include = ["Cargo.toml", "LICENSE", "README.md", "src/lib.rs"]
 rustdoc-args = ["--cfg=docsrs"]
 
 [features]
-default = ["std"]
+# All features are enabled by default. Because of how cargo works, if you want to disable features,
+# you have to disable all of them, then enable back those you need. For example:
+# - To disable "std", you need to enable ["alloc", "all"].
+# - To disable all bases but base32 and base64, you need to enable ["std", "base32", "base64"].
+default = ["std", "all"]
 alloc = []
 std = ["alloc"]
+all = ["base2", "base4", "base8", "base16", "base32", "base64"]
+base2 = []
+base4 = []
+base8 = []
+base16 = []
+base32 = []
+base64 = []

--- a/lib/macro/Cargo.toml
+++ b/lib/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-encoding-macro"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "MIT"
 edition = "2018"
@@ -14,5 +14,5 @@ description = "Macros for data-encoding"
 include = ["Cargo.toml", "LICENSE", "README.md", "src/lib.rs"]
 
 [dependencies]
-data-encoding = { version = "2.5.0", path = "..", default-features = false }
-data-encoding-macro-internal = { version = "0.1.12", path = "internal" }
+data-encoding = { version = "2.6.0", path = "..", default-features = false, features = ["all"] }
+data-encoding-macro-internal = { version = "0.1.13", path = "internal" }

--- a/lib/macro/internal/Cargo.toml
+++ b/lib/macro/internal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-encoding-macro-internal"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "MIT"
 edition = "2018"
@@ -14,10 +14,10 @@ include = ["Cargo.toml", "LICENSE", "README.md", "src/lib.rs"]
 proc-macro = true
 
 [dependencies.data-encoding]
-version = "2.5.0"
+version = "2.6.0"
 path = "../.."
 default-features = false
-features = ["alloc"]
+features = ["alloc", "all"]
 
 [dependencies.syn]
 version = "1"

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -202,11 +202,17 @@ macro_rules! define {
 
 define!(Bf: bool = false);
 define!(Bt: bool = true);
+#[cfg(feature = "base2")]
 define!(N1: usize = 1);
+#[cfg(feature = "base4")]
 define!(N2: usize = 2);
+#[cfg(feature = "base8")]
 define!(N3: usize = 3);
+#[cfg(feature = "base16")]
 define!(N4: usize = 4);
+#[cfg(feature = "base32")]
 define!(N5: usize = 5);
+#[cfg(feature = "base64")]
 define!(N6: usize = 6);
 
 #[derive(Copy, Clone)]
@@ -237,13 +243,19 @@ macro_rules! dispatch {
     };
     (let $var: ident: usize = $val: expr; $($body: tt)*) => {
         match $val {
+            #[cfg(feature = "base2")]
             1 => { let $var = N1; dispatch!($($body)*) },
+            #[cfg(feature = "base4")]
             2 => { let $var = N2; dispatch!($($body)*) },
+            #[cfg(feature = "base8")]
             3 => { let $var = N3; dispatch!($($body)*) },
+            #[cfg(feature = "base16")]
             4 => { let $var = N4; dispatch!($($body)*) },
+            #[cfg(feature = "base32")]
             5 => { let $var = N5; dispatch!($($body)*) },
+            #[cfg(feature = "base64")]
             6 => { let $var = N6; dispatch!($($body)*) },
-            _ => panic!(),
+            x => panic!("feature base{} is disabled", 1 << x),
         }
     };
     (let $var: ident: Option<$type: ty> = $val: expr; $($body: tt)*) => {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -137,9 +137,16 @@ impl Action {
                 instructions *= &[&["--release"]];
             }
             let features: &[&[&str]] = match self.dir {
-                Dir::Lib => {
-                    &[&["--no-default-features", "--features=alloc"], &["--no-default-features"]]
-                }
+                Dir::Lib => &[
+                    &["--no-default-features", "--features=alloc,all"],
+                    &["--no-default-features", "--features=all"],
+                    &["--no-default-features", "--features=base2"],
+                    &["--no-default-features", "--features=base4"],
+                    &["--no-default-features", "--features=base8"],
+                    &["--no-default-features", "--features=base16"],
+                    &["--no-default-features", "--features=base32"],
+                    &["--no-default-features", "--features=base64"],
+                ],
                 _ => &[],
             };
             instructions *= features;


### PR DESCRIPTION
This is a breaking change for those who use `default-features = false`. The fix is to add back the `all` feature.

Fixes #97