### PR TITLE
Upgrade `syn` dependency to v2

### DIFF
--- a/lib/macro/internal/Cargo.toml
+++ b/lib/macro/internal/Cargo.toml
@@ -20,6 +20,6 @@ default-features = false
 features = ["alloc"]
 
 [dependencies.syn]
-version = "2"
+version = ">= 1, < 3"
 default-features = false
 features = ["parsing", "proc-macro"]

--- a/lib/macro/internal/Cargo.toml
+++ b/lib/macro/internal/Cargo.toml
@@ -20,6 +20,6 @@ default-features = false
 features = ["alloc"]
 
 [dependencies.syn]
-version = "1"
+version = "2"
 default-features = false
 features = ["parsing", "proc-macro"]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(iter_intersperse)]
-
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::ffi::OsStr;


### PR DESCRIPTION
I've also removed the `#![feature(iter_intersperse)]` from xtask. The feature does not seem to be used anywhere but prevents it from being used on stable Rust.