### PR TITLE
Remove MSRV for unpublished crates

### DIFF
--- a/cmp/Cargo.toml
+++ b/cmp/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["ia0 <git@ia0.eu>"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.81"
 build = "build.rs"
 publish = false
 

--- a/nostd/Cargo.toml
+++ b/nostd/Cargo.toml
@@ -3,7 +3,6 @@ name = "nostd"
 version = "0.1.0"
 authors = ["Julien Cretin <cretin@google.com>"]
 edition = "2021"
-rust-version = "1.81"
 license = "MIT"
 publish = false
 

--- a/www/Cargo.toml
+++ b/www/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.81"
 repository = "https://github.com/ia0/data-encoding"
 description = "Website for data-encoding"
 publish = false


### PR DESCRIPTION
This was added as part of #114 for cargo audit.