### PR TITLE
Use doc_cfg instead of doc_auto_cfg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
       working-directory: lib/v3
     - name: cd lib && cargo +nightly doc
       env:
-        RUSTDOCFLAGS: --deny=warnings
+        RUSTDOCFLAGS: --deny=warnings --cfg=docsrs
       run: cargo +nightly doc
       working-directory: lib
     - name: cd lib/v3 && cargo +nightly miri test --test=lib

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Document maximum input length for `Encoding::{decode,encode}_len()` (fixes #145)
 - Add `Encoding::encode_align()` to decide where to split long inputs
 
+### Patch
+
+- Use `doc_cfg` instead of `doc_auto_cfg`
+
 ## 2.9.0
 
 ### Minor

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/data-encoding"
 description = "Efficient and customizable data-encoding functions like base64, base32, and hex"
 include = ["Cargo.toml", "LICENSE", "README.md", "src/lib.rs"]
 
-# TODO: Remove this once doc_auto_cfg is in the MSRV.
+# TODO: Remove this (and its lib and xtask counterpart) once doc_cfg is in the MSRV.
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg=docsrs"]
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -144,7 +144,7 @@
 //! [wrapping]: struct.Specification.html#structfield.wrap
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -146,6 +146,9 @@ impl Action {
                     &[&["--no-default-features", "--features=alloc"], &["--no-default-features"]];
             }
         }
+        if self.dir == Dir::Lib && self.task == Task::Doc {
+            instructions.0[0].env[0].1.push_str(" --cfg=docsrs");
+        }
         if self.dir == Dir::Nostd && self.task == Task::Test {
             instructions = Instructions::default();
             instructions += Instruction {


### PR DESCRIPTION
`doc_auto_cfg` has changed to `doc_cfg` in Rust nightly, so docs.rs builds including this package as a dependency will all fail. This fixes that. 

Once this PR is merged, please make another release on crates.io!