### PR TITLE
chore(cargo): remove deprecated package authors field

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "data-encoding-bin"
 version = "0.3.9"
-authors = ["Julien Cretin <git@ia0.eu>"]
 license = "MIT"
 edition = "2021"
 rust-version = "1.81"

--- a/cmp/Cargo.toml
+++ b/cmp/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cmp"
 version = "0.1.0"
-authors = ["ia0 <git@ia0.eu>"]
 license = "MIT"
 edition = "2021"
 build = "build.rs"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "data-encoding"
 version = "2.11.0"
-authors = ["Julien Cretin <git@ia0.eu>"]
 license = "MIT"
 edition = "2018"
 rust-version = "1.48"

--- a/lib/fuzz/Cargo.toml
+++ b/lib/fuzz/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "data-encoding-fuzz"
 version = "0.0.0"
-authors = ["Automatically generated"]
 publish = false
 edition = "2021"
 

--- a/lib/macro/Cargo.toml
+++ b/lib/macro/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "data-encoding-macro"
 version = "0.1.20"
-authors = ["Julien Cretin <cretin@google.com>"]
 license = "MIT"
 edition = "2018"
 rust-version = "1.48"

--- a/lib/macro/internal/Cargo.toml
+++ b/lib/macro/internal/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "data-encoding-macro-internal"
 version = "0.1.18"
-authors = ["Julien Cretin <cretin@google.com>"]
 license = "MIT"
 edition = "2018"
 rust-version = "1.48"

--- a/lib/v3/Cargo.toml
+++ b/lib/v3/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "data-encoding-v3"
 version = "0.1.1"
-authors = ["Julien Cretin <git@ia0.eu>"]
 license = "MIT"
 edition = "2024"
 rust-version = "1.85"

--- a/nostd/Cargo.toml
+++ b/nostd/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "nostd"
 version = "0.1.0"
-authors = ["Julien Cretin <cretin@google.com>"]
 edition = "2021"
 license = "MIT"
 publish = false

--- a/www/Cargo.toml
+++ b/www/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "data-encoding-www"
 version = "0.1.0"
-authors = ["Julien Cretin <cretin@google.com>"]
 license = "MIT"
 edition = "2021"
 repository = "https://github.com/ia0/data-encoding"


### PR DESCRIPTION
`package.authors` is deprecated: https://github.com/rust-lang/cargo/pull/15068
